### PR TITLE
(feat): Patch #1 of `Lang` methods implementation in Vanilla JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,49 @@ __lodash-recreated__ is a vanilla JavaScript Re-Creation of the popular library 
     If start is greater than end the params are swapped to support negative ranges.<br>
     https://lodash.com/docs/4.17.15#inRange
 
++ ## Lang
+    + __isArguments(value)__
+    > Checks if value is likely an `Arguments` object.<br>
+    https://lodash.com/docs/4.17.15#isArguments
+
+    + __isArray(value)__
+    > Checks if value is classified as an `Array` object.<br>
+    https://lodash.com/docs/4.17.15#isArray
+
+    + __isArrayBuffer(value)__
+    > Checks if value is classified as an `ArrayBuffer` object.<br>
+    https://lodash.com/docs/4.17.15#isArrayBuffer
+
+    + __isArrayLike(value)__
+    > Checks if value is array-like. A value is considered array-like if<br>
+    it's not a function and has a value.length that's an integer<br>
+    greater than or equal to 0 and less than or equal to Number.MAX_SAFE_INTEGER.<br>
+    https://lodash.com/docs/4.17.15#isArrayLike
+
+    + __isArrayLikeObject(value)__
+    > This method is like `isArrayLike` except that it also checks if value is an object.
+    https://lodash.com/docs/4.17.15#isArrayLikeObject
+
+    + __isBoolean(value)__
+    > Checks if value is classified as a boolean primitive or object.
+    https://lodash.com/docs/4.17.15#isBoolean
+
+    + __isBuffer(value)__
+    > Checks if value is a buffer.
+    https://lodash.com/docs/4.17.15#isBuffer
+
+    + __isDate(value)__
+    > Checks if value is classified as a Date object.
+    https://lodash.com/docs/4.17.15#isDate
+
+    + __isEmpty(value)__
+    > Checks if value is an empty object, collection, map, or set.<br>
+    Objects are considered empty if they have no own enumerable string keyed properties.<br>
+    Array-like values such as arguments objects, arrays, buffers, strings <br>
+    are considered empty if they have a length of 0.<br>
+    Similarly, maps and sets are considered empty if they have a size of 0.<br>
+    https://lodash.com/docs/4.17.15#isEmpty
+
 
 ## Running Tests
 The projects uses [Jest](https://jestjs.io/en/) JavaScript Testing Framework. to run all tests, all you have to do is run the command:

--- a/src/functions/lang.js
+++ b/src/functions/lang.js
@@ -1,3 +1,4 @@
+const { getObjectTag, isNonNullObject } = require('../utils');
 /**
  * Checks if object conforms to source by invoking
  * the predicate properties of source with the corresponding property values of object.
@@ -10,6 +11,145 @@ const conformsTo = (object, source) => {
   return Object.entries(source).every(([key, predicate]) => predicate(object[key]));
 }
 
+/**
+ * Checks if value is likely an arguments object.
+ * https://lodash.com/docs/4.17.15#isArguments
+ *
+ * @param {any} value - The value to check.
+ * @returns {boolean} - Returns true if value is `Arguments`, else false.
+ */
+const isArguments = (value) => {
+  return isNonNullObject(value) &&
+    getObjectTag(value) === '[object Arguments]';
+}
+
+/**
+ * Checks if value is classified as an Array object.
+ * https://lodash.com/docs/4.17.15#isArray
+ *
+ * @param {any} value - The value to check.
+ * @returns {boolean} - Returns `true` if value is `Array`, else false.
+ */
+const isArray = (value) => {
+  return value instanceof Array &&
+    getObjectTag(value) === '[object Array]';
+}
+
+/**
+ * Checks if value is classified as an ArrayBuffer object.
+ * https://lodash.com/docs/4.17.15#isArrayBuffer
+ *
+ * @param {any} value - The value to check.
+ * @returns {boolean} - Returns true if value is `ArrayBuffer`, else false.
+ */
+const isArrayBuffer = (value) => {
+  return value instanceof ArrayBuffer &&
+    getObjectTag(value) === '[object ArrayBuffer]';
+}
+
+/**
+ * Checks if value is array-like. A value is considered array-like if
+ * it's not a function and has a value.length that's
+ * an integer greater than or equal to 0 and less than or equal to Number.MAX_SAFE_INTEGER.
+ * https://lodash.com/docs/4.17.15#isArrayLike
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+const isArrayLike = (value) => {
+  return value != null &&
+    typeof(value) !== 'function' &&
+    (value['length'] >= 0 && value['length'] <= Number.MAX_SAFE_INTEGER);
+}
+
+/**
+ * This method is like isArrayLike(value) except
+ * that it also checks if value is an object.
+ * https://lodash.com/docs/4.17.15#isArrayLikeObject
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+const isArrayLikeObject = (value) => {
+  return isNonNullObject(value) &&
+    (value['length'] >= 0 && value['length'] <= Number.MAX_SAFE_INTEGER);
+}
+
+/**
+ * Checks if value is classified as a boolean primitive or object.
+ * https://lodash.com/docs/4.17.15#isBoolean
+ *
+ * @param {*} value - The value to check.
+ * @returns {boolean} - Returns true if value is a boolean, else false.
+ */
+const isBoolean = value => {
+  return typeof value === 'boolean' ||
+    (isNonNullObject(value) && (getObjectTag(value)) === '[object Boolean]');
+}
+
+/**
+ * Checks if value is a buffer.
+ * https://lodash.com/docs/4.17.15#isBuffer
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+const isBuffer = (value) => {
+  return isNonNullObject(value) &&
+    value instanceof Buffer &&
+    getObjectTag(value) === '[object Uint8Array]';
+}
+
+/**
+ * Checks if value is classified as a Date object.
+ * https://lodash.com/docs/4.17.15#isDate
+ *
+ * @param {any} value - The value to check.
+ * @returns {boolean}
+ */
+const isDate = value => {
+  return isNonNullObject(value) &&
+    value instanceof Date &&
+    getObjectTag(value) === '[object Date]';
+}
+
+/**
+ * Checks if value is an empty object, collection, map, or set.
+ * Objects are considered empty if they have no own enumerable string keyed properties.
+ *  Array-like values such as arguments objects, arrays, buffers, strings, or
+ * jQuery-like collections are considered empty if they have a length of 0.
+ * Similarly, maps and sets are considered empty if they have a size of 0.
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+const isEmpty = value => {
+  const isEmptyObjectByTag = {
+    '[object Map]': (map) => !map.size,
+    '[object Set]': (set) => !set.size,
+    '[object ArrayBuffer]': (arrayBuffer) => !arrayBuffer.byteLength,
+    '[object Object]': (obj) => JSON.stringify(obj) === JSON.stringify({})
+  };
+
+  if (isArrayLike(value)) {
+    return !value['length'];
+  } else if (typeof(value) === 'object') {
+    const tag = getObjectTag(value);
+    return (isEmptyObjectByTag[tag] ||(() => true))(value);
+  }
+
+  return true;
+}
+
 module.exports = {
-  conformsTo
+  conformsTo,
+  isArguments,
+  isArray,
+  isArrayBuffer,
+  isArrayLike,
+  isArrayLikeObject,
+  isBoolean,
+  isBuffer,
+  isDate,
+  isEmpty,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,3 +9,11 @@ module.exports.randomInt = function(lower, upper) {
 module.exports.randomFloat = function(lower, upper) {
   return Math.random() * (upper - lower) + lower;
 }
+
+module.exports.getObjectTag = function(obj) {
+  return Object.prototype.toString.call(obj);
+}
+
+module.exports.isNonNullObject = function(val) {
+  return typeof(val) === 'object' && val !== null;
+}

--- a/test/lang/isArguments.test.js
+++ b/test/lang/isArguments.test.js
@@ -1,0 +1,22 @@
+const { isArguments } = require('../../src/functions/lang');
+
+describe('isArguments(value)', () => {
+  it('Should Return `true` for `Arguments` objects', () => {
+    const toArgs = function() { return arguments; };
+    expect(isArguments(toArgs())).toEqual(true)
+    expect(isArguments(toArgs.call(null, 1, 2, 3))).toEqual(true);
+    expect(isArguments(toArgs.apply(undefined, [1, 2, 3]))).toEqual(true);
+    expect(isArguments(function(){ 'use strict'; return arguments; }(1, 2, 3))).toEqual(true);
+  });
+
+  it('Should Return `false` for non `Arguments` objects', () => {
+    expect(isArguments(1)).toBeFalsy();
+    expect(isArguments(/x/)).toBeFalsy();
+    expect(isArguments('a')).toBeFalsy();
+    expect(isArguments(true)).toBeFalsy();
+    expect(isArguments(new Date)).toBeFalsy();
+    expect(isArguments(new Error)).toBeFalsy();
+    expect(isArguments([1, 2, 3])).toBeFalsy();
+    expect(isArguments({ 'a': 1, 'b': 2})).toBeFalsy();
+  });
+});

--- a/test/lang/isArray.test.js
+++ b/test/lang/isArray.test.js
@@ -1,0 +1,21 @@
+const { isArray } = require('../../src/functions/lang');
+
+describe('isArray(value)', () => {
+  it('Should Return `true` for `Array` objects', () => {
+    expect(isArray([1, true, 'hello', new Date(), /x/g])).toEqual(true);
+  });
+
+  it('Should Return `false` for non-arrays', () => {
+    const args = (function() { return arguments; })();
+
+    expect(isArray(args)).toBeFalsy();
+    expect(isArray(1)).toBeFalsy();
+    expect(isArray(/x/)).toBeFalsy();
+    expect(isArray('a')).toBeFalsy();
+    expect(isArray(true)).toBeFalsy();
+    expect(isArray(new Date)).toBeFalsy();
+    expect(isArray(new Error)).toBeFalsy();
+    expect(isArray({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isArray(Array.prototype.slice)).toBeFalsy();
+  });
+});

--- a/test/lang/isArrayBuffer.test.js
+++ b/test/lang/isArrayBuffer.test.js
@@ -1,0 +1,22 @@
+const { isArrayBuffer } = require('../../src/functions/lang');
+
+describe('isArrayBuffer(value)', () => {
+  it('Should Return `true` for `ArrayBuffer` objects', () => {
+    expect(isArrayBuffer(new ArrayBuffer(2))).toEqual(true);
+  });
+
+  it('Should Return `false` for non Array Buffer', () => {
+    const args = (function() { return arguments; })();
+
+    expect(isArrayBuffer(args)).toBeFalsy();
+    expect(isArrayBuffer(1)).toBeFalsy();
+    expect(isArrayBuffer(/x/)).toBeFalsy();
+    expect(isArrayBuffer('a')).toBeFalsy();
+    expect(isArrayBuffer(true)).toBeFalsy();
+    expect(isArrayBuffer(new Date)).toBeFalsy();
+    expect(isArrayBuffer(new Error)).toBeFalsy();
+    expect(isArrayBuffer({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isArrayBuffer(Array.prototype.slice)).toBeFalsy();
+    expect(isArrayBuffer([1, true, 'hello', new Date(), /x/g])).toBeFalsy();
+  });
+});

--- a/test/lang/isArrayLike.test.js
+++ b/test/lang/isArrayLike.test.js
@@ -1,0 +1,30 @@
+const { isArrayLike } = require('../../src/functions/lang');
+
+describe('isArrayLike(value)', () => {
+  it('Should Return `true` for Array-Like objects', () => {
+    const arrayLike = [
+      'foo',
+      {'0': 'a', 'length': 1},
+      Buffer.from(new ArrayBuffer(2)),
+      [1, true, 'foo', new Date(), /x/g],
+      (function() {return arguments;}).apply(null, [1, 2, 3])
+    ];
+
+    const expected = arrayLike.map(() => true);
+    const actual = arrayLike.map(isArrayLike);
+    expect(actual).toEqual(expected);
+  });
+
+  it('Should Return `false` for non ArrayLike values', () => {
+    expect(isArrayLike(null)).toBeFalsy();
+    expect(isArrayLike(undefined)).toBeFalsy();
+    expect(isArrayLike(1)).toBeFalsy();
+    expect(isArrayLike(/x/)).toBeFalsy();
+    expect(isArrayLike(true)).toBeFalsy();
+    expect(isArrayLike(new Date)).toBeFalsy();
+    expect(isArrayLike(new Error)).toBeFalsy();
+    expect(isArrayLike({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isArrayLike(new ArrayBuffer(2))).toBeFalsy();
+    expect(isArrayLike(Array.prototype.slice)).toBeFalsy();
+  });
+});

--- a/test/lang/isArrayLikeObject.test.js
+++ b/test/lang/isArrayLikeObject.test.js
@@ -1,0 +1,26 @@
+const { isArrayLikeObject } = require('../../src/functions/lang');
+
+describe('isArrayLikeObject(value)', () => {
+  it('Should Return `true` for Array-Like objects', () => {
+    const arrayLikeObjects = [
+      {'0': 'a', 'length': 1},
+      [1, true, 'foo', new Date(), /x/g],
+      (function() {return arguments;}).apply(null, [1, 2, 3])
+    ];
+
+    const expected = arrayLikeObjects.map(() => true);
+    const actual = arrayLikeObjects.map(isArrayLikeObject);
+    expect(actual).toEqual(expected);
+  });
+
+  it('Should Return `false` for Non ArrayLikeObject values', () => {
+    expect(isArrayLikeObject(1)).toBeFalsy();
+    expect(isArrayLikeObject(/x/)).toBeFalsy();
+    expect(isArrayLikeObject(true)).toBeFalsy();
+    expect(isArrayLikeObject(new Date)).toBeFalsy();
+    expect(isArrayLikeObject(new Error)).toBeFalsy();
+    expect(isArrayLikeObject({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isArrayLikeObject(new ArrayBuffer(2))).toBeFalsy();
+    expect(isArrayLikeObject(Array.prototype.slice)).toBeFalsy();
+  });
+});

--- a/test/lang/isBoolean.test.js
+++ b/test/lang/isBoolean.test.js
@@ -1,0 +1,25 @@
+const { isBoolean } = require('../../src/functions/lang');
+
+describe('isBoolean(value)', () => {
+  it('Should Return `true` for `Boolean`', () => {
+    const booleans = [true, false, Object(true), Object(false)];
+    const actual = booleans.map(isBoolean);
+    const expected = booleans.map(() => true);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('Should Return `false` for non booleans', () => {
+    const toArgs = function() { return arguments; };
+
+    expect(isBoolean(1)).toBeFalsy();
+    expect(isBoolean(/x/)).toBeFalsy();
+    expect(isBoolean('a')).toBeFalsy();
+    expect(isBoolean(new Date)).toBeFalsy();
+    expect(isBoolean(new Error)).toBeFalsy();
+    expect(isBoolean([1, 2, 3])).toBeFalsy();
+    expect(isBoolean({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isBoolean(Array.prototype.slice)).toBeFalsy();
+    expect(isBoolean(toArgs.apply(null, [1, 2, 3]))).toBeFalsy();
+  });
+});

--- a/test/lang/isBuffer.test.js
+++ b/test/lang/isBuffer.test.js
@@ -1,0 +1,23 @@
+const { isBuffer } = require('../../src/functions/lang');
+
+describe('isBuffer(value)', () => {
+  it('Should Return `true` for `Buffer` objects', () => {
+    expect(isBuffer(Buffer.from(new ArrayBuffer(2)))).toEqual(true);
+  });
+
+  it('Should Return `false` for non-buffers', () => {
+    const args = (function() { return arguments; })();
+
+    expect(isBuffer(args)).toBeFalsy();
+    expect(isBuffer(1)).toBeFalsy();
+    expect(isBuffer(/x/)).toBeFalsy();
+    expect(isBuffer('a')).toBeFalsy();
+    expect(isBuffer(true)).toBeFalsy();
+    expect(isBuffer(new Date)).toBeFalsy();
+    expect(isBuffer(new Error)).toBeFalsy();
+    expect(isBuffer({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isBuffer(new ArrayBuffer(2))).toBeFalsy();
+    expect(isBuffer(Array.prototype.slice)).toBeFalsy();
+    expect(isBuffer([1, true, 'hello', new Date(), /x/g])).toBeFalsy();
+  });
+});

--- a/test/lang/isDate.test.js
+++ b/test/lang/isDate.test.js
@@ -1,0 +1,23 @@
+const { isDate } = require('../../src/functions/lang');
+
+describe('isDate(value)', () => {
+  it('Should Return `true` for `Date` objects', () => {
+    expect(isDate(new Date())).toEqual(true);
+  });
+
+  it('Should Return `false` for non-date', () => {
+    const args = (function() { return arguments; })();
+
+    expect(isDate(1)).toBeFalsy();
+    expect(isDate(/x/)).toBeFalsy();
+    expect(isDate('a')).toBeFalsy();
+    expect(isDate(true)).toBeFalsy();
+    expect(isDate(args)).toBeFalsy();
+    expect(isDate([1, 2, 3])).toBeFalsy();
+    expect(isDate(new Error)).toBeFalsy();
+    expect(isDate({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isDate(new ArrayBuffer(2))).toBeFalsy();
+    expect(isDate(Array.prototype.slice)).toBeFalsy();
+    expect(isDate(Buffer.from(new ArrayBuffer(2)))).toBeFalsy();
+  });
+});

--- a/test/lang/isEmpty.test.js
+++ b/test/lang/isEmpty.test.js
@@ -1,0 +1,37 @@
+const { isEmpty } = require('../../src/functions/lang');
+
+const args = function() { return arguments; };
+
+describe('isEmpty(value)', () => {
+  it('Should Return `true` for `Empty` values', () => {
+    const empties = [[], {}, null, undefined, false, 0, NaN, ''];
+    const actual = empties.map(isEmpty);
+    const expected = empties.map(() => true);
+
+    expect(actual).toEqual(expected);
+
+    expect(isEmpty()).toEqual(true);
+    expect(isEmpty(1)).toEqual(true);
+    expect(isEmpty(NaN)).toEqual(true);
+    expect(isEmpty(/x/)).toEqual(true);
+    expect(isEmpty(true)).toEqual(true);
+    expect(isEmpty(Array.prototype.slice)).toEqual(true);
+
+    expect(isEmpty(new Set())).toEqual(true);
+    expect(isEmpty(new Map())).toEqual(true);
+    expect(isEmpty(args.call(null))).toEqual(true);
+    expect(isEmpty(new ArrayBuffer())).toEqual(true);
+    expect(isEmpty(Buffer.from(new ArrayBuffer(0)))).toEqual(true);
+  });
+
+  it('Should Return `false` for non-empty values', () => {
+    expect(isEmpty('a')).toBeFalsy();
+    expect(isEmpty([1, 2, 3])).toBeFalsy();
+    expect(isEmpty({ 'a': 1, 'b': 2})).toBeFalsy();
+    expect(isEmpty(new Set([1, 2,3]))).toBeFalsy();
+    expect(isEmpty(new ArrayBuffer(2))).toBeFalsy();
+    expect(isEmpty(Buffer.alloc(1000))).toBeFalsy();
+    expect(isEmpty(new Map().set('a', 1))).toBeFalsy();
+    expect(isEmpty(args.call(null, 1, 2, 3))).toBeFalsy();
+  });
+});


### PR DESCRIPTION
 + __isArguments(value)__
    > Checks if value is likely an `Arguments` object.<br>
    https://lodash.com/docs/4.17.15#isArguments

    + __isArray(value)__
    > Checks if value is classified as an `Array` object.<br>
    https://lodash.com/docs/4.17.15#isArray

    + __isArrayBuffer(value)__
    > Checks if value is classified as an `ArrayBuffer` object.<br>
    https://lodash.com/docs/4.17.15#isArrayBuffer

    + __isArrayLike(value)__
    > Checks if value is array-like. A value is considered array-like if<br>
    it's not a function and has a value.length that's an integer<br>
    greater than or equal to 0 and less than or equal to Number.MAX_SAFE_INTEGER.<br>
    https://lodash.com/docs/4.17.15#isArrayLike

    + __isArrayLikeObject(value)__
    > This method is like `isArrayLike` except that it also checks if value is an object.<br>
    https://lodash.com/docs/4.17.15#isArrayLikeObject

    + __isBoolean(value)__
    > Checks if value is classified as a boolean primitive or object.<br>
    https://lodash.com/docs/4.17.15#isBoolean

    + __isBuffer(value)__
    > Checks if value is a buffer.<br>
    https://lodash.com/docs/4.17.15#isBuffer

    + __isDate(value)__
    > Checks if value is classified as a Date object.<br>
    https://lodash.com/docs/4.17.15#isDate

    + __isEmpty(value)__
    > Checks if value is an empty object, collection, map, or set.<br>
    Objects are considered empty if they have no own enumerable string keyed properties.<br>
    Array-like values such as arguments objects, arrays, buffers, strings <br>
    are considered empty if they have a length of 0.<br>
    Similarly, maps and sets are considered empty if they have a size of 0.<br>
    https://lodash.com/docs/4.17.15#isEmpty